### PR TITLE
Feat: Add stock editing functionality to Store view

### DIFF
--- a/gym_punto_venta/lib/Screens/PrincipalScreen.dart
+++ b/gym_punto_venta/lib/Screens/PrincipalScreen.dart
@@ -10,6 +10,7 @@ import 'package:gym_punto_venta/screens/settings_screen.dart'; // Added
 import 'package:gym_punto_venta/screens/product_registration_screen.dart'; // Added for product registration
 import 'package:gym_punto_venta/widgets/product_list.dart'; // Added for ProductList widget
 import 'package:gym_punto_venta/widgets/sales_summary.dart'; // Added for SalesSummary widget
+import 'package:gym_punto_venta/dialogs/edit_stock_dialog.dart'; // Added for EditStockDialog
 import '../models/product.dart'; // Added for Product model
 import '../functions/funtions.dart';
 import '../models/clients.dart';
@@ -148,6 +149,40 @@ class GymManagementScreenState extends State<GymManagementScreen> {
     }
   }
 
+  void _updateProductStock(Product productToUpdate, int newStock) {
+    if (mounted) {
+      setState(() {
+        final productIndex = _products.indexWhere((p) => p.id == productToUpdate.id);
+        if (productIndex != -1) {
+          _products[productIndex] = _products[productIndex].copyWith(stock: newStock);
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text('Stock de ${productToUpdate.name} actualizado a $newStock.')),
+          );
+        } else {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text('Error: Producto ${productToUpdate.name} no encontrado para actualizar stock.')),
+          );
+        }
+      });
+    }
+  }
+
+  Future<void> _showEditStockDialog(Product product) async {
+    final newStock = await showDialog<int>(
+      context: context,
+      builder: (BuildContext dialogContext) {
+        return EditStockDialog(
+          product: product,
+          darkMode: _darkMode,
+        );
+      },
+    );
+
+    if (newStock != null) {
+      _updateProductStock(product, newStock);
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     // Ensure _functions is initialized before trying to access its properties in build
@@ -278,6 +313,7 @@ class GymManagementScreenState extends State<GymManagementScreen> {
                   products: _products,
                   darkMode: _darkMode,
                   onSellProduct: _sellProduct,
+                   onEditStockProduct: _showEditStockDialog, // Pasar el nuevo callback
                 ),
               ),
             ] else ...[

--- a/gym_punto_venta/lib/dialogs/edit_stock_dialog.dart
+++ b/gym_punto_venta/lib/dialogs/edit_stock_dialog.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:gym_punto_venta/models/product.dart'; // Asegúrate que la ruta es correcta
+
+class EditStockDialog extends StatefulWidget {
+  final Product product;
+  final bool darkMode;
+
+  const EditStockDialog({
+    Key? key,
+    required this.product,
+    required this.darkMode,
+  }) : super(key: key);
+
+  @override
+  _EditStockDialogState createState() => _EditStockDialogState();
+}
+
+class _EditStockDialogState extends State<EditStockDialog> {
+  final _formKey = GlobalKey<FormState>();
+  late TextEditingController _stockController;
+
+  @override
+  void initState() {
+    super.initState();
+    // Inicializa el controlador con el stock actual del producto
+    _stockController = TextEditingController(text: widget.product.stock.toString());
+  }
+
+  @override
+  void dispose() {
+    _stockController.dispose();
+    super.dispose();
+  }
+
+  void _saveStock() {
+    if (_formKey.currentState!.validate()) {
+      final newStock = int.tryParse(_stockController.text);
+      if (newStock != null) {
+        Navigator.of(context).pop(newStock); // Devuelve el nuevo valor de stock
+      } else {
+        // Esto no debería ocurrir si la validación es correcta
+        Navigator.of(context).pop();
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final inputDecoration = InputDecoration(
+      labelStyle: TextStyle(color: widget.darkMode ? Colors.white70 : Colors.black54),
+      enabledBorder: UnderlineInputBorder(
+        borderSide: BorderSide(color: widget.darkMode ? Colors.white54 : Colors.black38),
+      ),
+      focusedBorder: UnderlineInputBorder(
+        borderSide: BorderSide(color: widget.darkMode ? Colors.blueAccent : Colors.blue),
+      ),
+      errorBorder: UnderlineInputBorder(
+        borderSide: BorderSide(color: widget.darkMode ? Colors.redAccent : Colors.red),
+      ),
+      focusedErrorBorder: UnderlineInputBorder(
+        borderSide: BorderSide(color: widget.darkMode ? Colors.redAccent : Colors.red, width: 2.0),
+      ),
+    );
+    final textStyle = TextStyle(color: widget.darkMode ? Colors.white : Colors.black);
+
+    return AlertDialog(
+      backgroundColor: widget.darkMode ? Colors.grey[850] : Colors.white,
+      title: Text(
+        'Editar Stock de ${widget.product.name}',
+        style: TextStyle(color: widget.darkMode ? Colors.white : Colors.blue[700], fontSize: 18),
+        overflow: TextOverflow.ellipsis,
+        maxLines: 2,
+      ),
+      content: Form(
+        key: _formKey,
+        child: TextFormField(
+          controller: _stockController,
+          decoration: inputDecoration.copyWith(labelText: 'Nueva Cantidad de Stock'),
+          style: textStyle,
+          keyboardType: TextInputType.number,
+          inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+          validator: (value) {
+            if (value == null || value.isEmpty) {
+              return 'Por favor ingrese una cantidad';
+            }
+            final n = int.tryParse(value);
+            if (n == null) {
+              return 'Por favor ingrese un número válido';
+            }
+            if (n < 0) {
+              return 'El stock no puede ser negativo';
+            }
+            return null;
+          },
+          autofocus: true,
+        ),
+      ),
+      actions: <Widget>[
+        TextButton(
+          child: Text('Cancelar', style: TextStyle(color: widget.darkMode ? Colors.redAccent[100] : Colors.red)),
+          onPressed: () {
+            Navigator.of(context).pop(); // Devuelve null
+          },
+        ),
+        ElevatedButton(
+          style: ElevatedButton.styleFrom(
+            backgroundColor: widget.darkMode ? Colors.teal : Colors.blue,
+            foregroundColor: Colors.white,
+          ),
+          onPressed: _saveStock,
+          child: const Text('Guardar'),
+        ),
+      ],
+    );
+  }
+}

--- a/gym_punto_venta/lib/widgets/product_card.dart
+++ b/gym_punto_venta/lib/widgets/product_card.dart
@@ -5,12 +5,14 @@ class ProductCard extends StatelessWidget {
   final Product product;
   final bool darkMode;
   final VoidCallback onSell; // Callback para cuando se presiona el botón de vender
+  final VoidCallback onEditStock; // Callback para editar el stock
 
   const ProductCard({
     Key? key,
     required this.product,
     required this.darkMode,
     required this.onSell,
+    required this.onEditStock, // Añadir el nuevo callback
   }) : super(key: key);
 
   @override
@@ -74,21 +76,29 @@ class ProductCard extends StatelessWidget {
               ],
             ),
             const SizedBox(height: 12.0),
-            Align(
-              alignment: Alignment.centerRight,
-              child: ElevatedButton.icon(
-                icon: Icon(product.stock > 0 ? Icons.shopping_cart_checkout : Icons.remove_shopping_cart_outlined, size: 18),
-                label: Text(product.stock > 0 ? 'Vender Unidad' : 'Sin Stock'),
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: product.stock > 0 ? enabledButtonColor : disabledButtonColor,
-                  foregroundColor: product.stock > 0 ? enabledButtonTextColor : subtextColor,
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(8.0),
-                  ),
-                  padding: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 8.0),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                IconButton(
+                  icon: Icon(Icons.edit_note, color: darkMode ? Colors.blue[200] : Colors.blue[700]),
+                  tooltip: 'Editar Stock',
+                  onPressed: onEditStock,
                 ),
-                onPressed: product.stock > 0 ? onSell : null, // Deshabilita si no hay stock
-              ),
+                const SizedBox(width: 8),
+                ElevatedButton.icon(
+                  icon: Icon(product.stock > 0 ? Icons.shopping_cart_checkout : Icons.remove_shopping_cart_outlined, size: 18),
+                  label: Text(product.stock > 0 ? 'Vender' : 'Sin Stock'), // Texto más corto para el botón
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: product.stock > 0 ? enabledButtonColor : disabledButtonColor,
+                    foregroundColor: product.stock > 0 ? enabledButtonTextColor : subtextColor,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(8.0),
+                    ),
+                    padding: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 8.0),
+                  ),
+                  onPressed: product.stock > 0 ? onSell : null, // Deshabilita si no hay stock
+                ),
+              ],
             ),
           ],
         ),

--- a/gym_punto_venta/lib/widgets/product_list.dart
+++ b/gym_punto_venta/lib/widgets/product_list.dart
@@ -6,12 +6,14 @@ class ProductList extends StatelessWidget {
   final List<Product> products;
   final bool darkMode;
   final Function(Product) onSellProduct; // Callback para vender un producto específico
+  final Function(Product) onEditStockProduct; // Callback para editar stock de un producto específico
 
   const ProductList({
     Key? key,
     required this.products,
     required this.darkMode,
     required this.onSellProduct,
+    required this.onEditStockProduct, // Añadir el nuevo callback
   }) : super(key: key);
 
   @override
@@ -40,7 +42,8 @@ class ProductList extends StatelessWidget {
         return ProductCard(
           product: product,
           darkMode: darkMode,
-          onSell: () => onSellProduct(product), // Pasa el producto específico al callback
+          onSell: () => onSellProduct(product),
+          onEditStock: () => onEditStockProduct(product), // Pasa el producto específico al nuevo callback
         );
       },
     );


### PR DESCRIPTION
- Modified ProductCard to include an 'Edit Stock' IconButton and a corresponding onEditStock callback.
- Created EditStockDialog: a dialog that allows users to input a new stock quantity for a product, with validation.
- Updated ProductList to pass the onEditStock callback from PrincipalScreen to each ProductCard.
- Implemented logic in PrincipalScreenState:
  - `_showEditStockDialog(Product product)`: Displays the EditStockDialog and retrieves the new stock value.
  - `_updateProductStock(Product product, int newStock)`: Updates the product's stock in the state and refreshes the UI.
- Connected the edit stock button in ProductCard to trigger the dialog and update the stock via callbacks.