### PR TITLE
Feat: Implement SQLite persistence for products

### DIFF
--- a/gym_punto_venta/lib/functions/funtions.dart
+++ b/gym_punto_venta/lib/functions/funtions.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'dart:convert';
 import 'package:gym_punto_venta/models/clients.dart';
+import 'package:gym_punto_venta/models/product.dart'; // Importar Product
 import 'package:gym_punto_venta/dialogs/add_client_dialog.dart';
 import 'package:gym_punto_venta/dialogs/edit_client_dialog.dart';
 import 'package:gym_punto_venta/dialogs/renew_client_dialog.dart';
@@ -664,5 +665,25 @@ void renewClientDialog(Client client, BuildContext mainContext) {
     } catch (e) {
       return "Error during biometric authentication: $e. Available types: $biometricsString";
     }
+  }
+
+  // --- Product Database Operations ---
+
+  Future<List<Product>> loadProductsFromDB() async {
+    return await dbHelper.getAllProducts();
+  }
+
+  Future<void> saveNewProductToDB(Product product) async {
+    await dbHelper.insertProduct(product);
+    // Podríamos querer actualizar alguna lista en memoria aquí o depender de que PrincipalScreen lo haga.
+    // Por ahora, solo guardamos. La carga se hará en initState de PrincipalScreen.
+  }
+
+  Future<void> updateProductInDB(Product product) async {
+    await dbHelper.updateProduct(product);
+  }
+
+  Future<void> deleteProductFromDB(String id) async {
+    await dbHelper.deleteProduct(id);
   }
 }

--- a/gym_punto_venta/lib/models/product.dart
+++ b/gym_punto_venta/lib/models/product.dart
@@ -32,24 +32,24 @@ class Product {
     );
   }
 
-  // Opcional: Métodos toJson y fromJson si planeamos persistencia de datos más adelante
-  // Map<String, dynamic> toJson() {
-  //   return {
-  //     'id': id,
-  //     'name': name,
-  //     'category': category,
-  //     'price': price,
-  //     'stock': stock,
-  //   };
-  // }
+  // Métodos para la persistencia con sqflite
+  Map<String, dynamic> toMap() {
+    return {
+      'id': id,
+      'name': name,
+      'category': category,
+      'price': price,
+      'stock': stock,
+    };
+  }
 
-  // factory Product.fromJson(Map<String, dynamic> json) {
-  //   return Product(
-  //     id: json['id'] as String,
-  //     name: json['name'] as String,
-  //     category: json['category'] as String,
-  //     price: json['price'] as double,
-  //     stock: json['stock'] as int,
-  //   );
-  // }
+  factory Product.fromMap(Map<String, dynamic> map) {
+    return Product(
+      id: map['id'] as String,
+      name: map['name'] as String,
+      category: map['category'] as String,
+      price: map['price'] as double,
+      stock: map['stock'] as int,
+    );
+  }
 }


### PR DESCRIPTION
- Updated DatabaseHelper to include a 'products' table with columns (id, name, category, price, stock) and corresponding CRUD methods (insertProduct, getAllProducts, updateProduct, deleteProduct).
- Added toMap() and fromMap() methods to the Product model for database interaction.
- Integrated product database operations into GymManagementFunctions (loadProductsFromDB, saveNewProductToDB, updateProductInDB).
- Modified PrincipalScreenState:
  - Products are now loaded from the database on initialization.
  - Product creation (_addProduct), sales (_sellProduct), and stock edits (_updateProductStock) now persist changes to the SQLite database in addition to updating the in-memory state and UI.
- ProductRegistrationScreen remains unchanged as its onProductSaved callback now triggers persistence via PrincipalScreenState.
- Ensured asynchronous operations for database interactions are handled correctly.