### PR TITLE
Fix: Ensure products table creation by incrementing DB version

### DIFF
--- a/gym_punto_venta/lib/database/database_helper.dart
+++ b/gym_punto_venta/lib/database/database_helper.dart
@@ -23,8 +23,9 @@ class DatabaseHelper {
     String path = join(await getDatabasesPath(), 'gym_database.db');
     return await openDatabase(
       path,
-      version: 1,
+      version: 2, // Incremented version to trigger _onCreate or _onUpgrade
       onCreate: _onCreate,
+      // Optionally, define onUpgrade and onDowngrade for more complex migrations
     );
   }
 


### PR DESCRIPTION
Increments the SQLite database version from 1 to 2. This change ensures that the _onCreate method is triggered for existing installations where the 'products' table might be missing, resolving the 'no such table: products' error.