### PR TITLE
Fix: Use explicit FFI factory, new DB name for initialization

### DIFF
--- a/gym_punto_venta/lib/database/database_helper.dart
+++ b/gym_punto_venta/lib/database/database_helper.dart
@@ -1,10 +1,13 @@
 import 'dart:async';
 import 'package:path/path.dart';
 import 'package:sqflite/sqflite.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart'; // Explicit FFI import
 import '../models/clients.dart'; // Added import for Client model
 import '../models/product.dart'; // Added import for Product model
 
 class DatabaseHelper {
+  static const String TABLE_PRODUCTS = 'products'; // Nombre de la tabla de productos
+  static const String DB_NAME = 'gym_database_fresh_v3.db'; // New DB name
 
   static final DatabaseHelper _instance = DatabaseHelper._internal();
   factory DatabaseHelper() => _instance;
@@ -19,25 +22,24 @@ class DatabaseHelper {
   }
 
   Future<Database> _initDb() async {
-    String path = join(await getDatabasesPath(), 'gym_database.db');
-    print("DatabaseHelper: _initDb: Database path: $path");
+    String path = join(await getDatabasesPath(), DB_NAME); // Use new DB name
+    print("DatabaseHelper: _initDb: Database path: $path (Using explicit FFI factory and new DB name)");
 
-    // Aggressively delete the database file before opening for FFI environments
-    // to ensure _onCreate is always called on a fresh database.
-    // Ensure databaseFactory is correctly set (e.g. to databaseFactoryFfi in main.dart for desktop)
     try {
-      print("DatabaseHelper: _initDb: Attempting to delete existing database at $path");
-      await databaseFactory.deleteDatabase(path);
-      print("DatabaseHelper: _initDb: Successfully deleted database at $path");
+      print("DatabaseHelper: _initDb: Attempting to delete existing database at $path using databaseFactoryFfi");
+      await databaseFactoryFfi.deleteDatabase(path); // Explicitly use databaseFactoryFfi
+      print("DatabaseHelper: _initDb: Successfully deleted database at $path using databaseFactoryFfi");
     } catch (e) {
-      print("DatabaseHelper: _initDb: Error deleting database at $path: $e");
+      print("DatabaseHelper: _initDb: Error deleting database at $path using databaseFactoryFfi: $e");
     }
 
-    return await openDatabase(
+    return await databaseFactoryFfi.openDatabase( // Explicitly use databaseFactoryFfi
       path,
-      version: 2, // Version can be 2 or incremented further if needed.
-      onCreate: _onCreate,
-      onUpgrade: _onUpgrade,
+      options: OpenDatabaseOptions( // Use OpenDatabaseOptions for FFI
+        version: 3, // Incremented version
+        onCreate: _onCreate,
+        onUpgrade: _onUpgrade,
+      )
     );
   }
 
@@ -60,33 +62,6 @@ class DatabaseHelper {
       // Handle other potential upgrade paths if necessary in the future.
       // For now, if not from v1, this path might not be strictly needed if deletion in _initDb works.
       print("DatabaseHelper: _onUpgrade: Unhandled upgrade path from v$oldVersion to v$newVersion or deletion in _initDb handled it.");
-        await db.execute("DROP TABLE IF EXISTS products");
-        // Re-create all tables
-        await _onCreate(db, newVersion);
-      } else {
-        // Handle other upgrade paths if necessary in the future
-        // For now, if not coming from v1, we could also just recreate.
-        // Or, if a future version 3 needs specific handling from v2:
-        // if (oldVersion == 2 && newVersion == 3) { /* specific v2 to v3 logic */ }
-        print("Performing generic upgrade: Re-calling _onCreate. This might need specific migration paths for data preservation in production.");
-        // Potentially drop tables or attempt to add missing ones.
-        // Calling _onCreate directly might fail if tables already exist.
-        // A safer generic approach for development might be to drop and recreate if not v1.
-        // However, the most common scenario for this error is a missing 'products' table from v1.
-        // If oldVersion is not 1, and _onCreate is called, it will try to create tables that might exist.
-        // The provided _onCreate uses "CREATE TABLE" not "CREATE TABLE IF NOT EXISTS" for all tables.
-        // So, to be safe, if not handling a specific known upgrade path like 1 to 2,
-        // we should consider if _onCreate is safe to call or if we need more granular ALTERs.
-        // Given the current problem, the v1->v2 path is the critical one.
-        // If this _onUpgrade is called for other version changes, the following _onCreate
-        // will likely throw errors if tables already exist.
-        // A more robust general upgrade would require specific ALTER TABLE statements.
-        // For this fix, focusing on the 1->2 path.
-        // If just adding products table was the goal for v1->v2:
-        // await db.execute('''CREATE TABLE $TABLE_PRODUCTS (...)''');
-        // await db.execute('CREATE INDEX IF NOT EXISTS idx_product_name ON $TABLE_PRODUCTS(name)');
-        // await db.execute('CREATE INDEX IF NOT EXISTS idx_product_category ON $TABLE_PRODUCTS(category)');
-      }
     }
   }
 
@@ -186,7 +161,7 @@ class DatabaseHelper {
 
     // Crear tabla de Productos
     await db.execute('''
-      CREATE TABLE products (
+      CREATE TABLE $TABLE_PRODUCTS (
         id TEXT PRIMARY KEY,
         name TEXT NOT NULL,
         category TEXT,
@@ -194,10 +169,10 @@ class DatabaseHelper {
         stock INTEGER NOT NULL
       )
     ''');
-    await db.execute('CREATE INDEX IF NOT EXISTS idx_product_name ON products(name)');
-    await db.execute('CREATE INDEX IF NOT EXISTS idx_product_category ON products(category)'); // Added index for category
+    await db.execute('CREATE INDEX IF NOT EXISTS idx_product_name ON $TABLE_PRODUCTS(name)');
+    await db.execute('CREATE INDEX IF NOT EXISTS idx_product_category ON $TABLE_PRODUCTS(category)'); // Added index for category
 
-    print("Database created with tables Clients, Memberships, AppSettings, Income, Expenses, PriceHistory, products, and Indexes!");
+    print("Database created with tables Clients, Memberships, AppSettings, Income, Expenses, PriceHistory, $TABLE_PRODUCTS, and Indexes!");
   }
 
   // Client CRUD Methods
@@ -427,13 +402,13 @@ class DatabaseHelper {
   // Product CRUD Methods
   Future<void> insertProduct(Product product) async {
     final db = await database;
-    await db.insert('products', product.toJson(), // Changed to toJson
+    await db.insert(TABLE_PRODUCTS, product.toJson(), // Changed to toJson
         conflictAlgorithm: ConflictAlgorithm.replace);
   }
 
   Future<List<Product>> getAllProducts() async {
     final db = await database;
-    final List<Map<String, dynamic>> maps = await db.query('products', orderBy: 'name ASC');
+    final List<Map<String, dynamic>> maps = await db.query(TABLE_PRODUCTS, orderBy: 'name ASC');
     return List.generate(maps.length, (i) {
       return Product.fromJson(maps[i]); // Changed to fromJson
     });
@@ -442,7 +417,7 @@ class DatabaseHelper {
   Future<Product?> getProductById(String id) async {
     final db = await database;
     final List<Map<String, dynamic>> maps = await db.query(
-      'products',
+      TABLE_PRODUCTS,
       where: 'id = ?',
       whereArgs: [id],
     );
@@ -455,7 +430,7 @@ class DatabaseHelper {
   Future<void> updateProduct(Product product) async {
     final db = await database;
     await db.update(
-      'products',
+      TABLE_PRODUCTS,
       product.toJson(), // Changed to toJson
       where: 'id = ?',
       whereArgs: [product.id],
@@ -465,7 +440,7 @@ class DatabaseHelper {
   Future<void> deleteProduct(String id) async {
     final db = await database;
     await db.delete(
-      'products',
+      TABLE_PRODUCTS,
       where: 'id = ?',
       whereArgs: [id],
     );
@@ -474,7 +449,7 @@ class DatabaseHelper {
   Future<void> updateProductStock(String id, int newStock) async {
     final db = await database;
     await db.update(
-      'products',
+      TABLE_PRODUCTS,
       {'stock': newStock},
       where: 'id = ?',
       whereArgs: [id],


### PR DESCRIPTION
- Modified DatabaseHelper._initDb to explicitly use `databaseFactoryFfi` for both `deleteDatabase` and `openDatabase` calls.
- Changed the database filename to 'gym_database_fresh_v3.db' to ensure a completely new database file is targeted, bypassing potential issues with the old file.
- Incremented the database version to 3.
- Ensured OpenDatabaseOptions is used with `databaseFactoryFfi.openDatabase`.

This is a more aggressive attempt to resolve the persistent 'no such table: products' error in FFI environments by ensuring the FFI-specific factory is used and that initialization occurs on a definitively new database file.