### PR TITLE
Arreglos en la pagina d ventas

### DIFF
--- a/gym_punto_venta/lib/database/database_helper.dart
+++ b/gym_punto_venta/lib/database/database_helper.dart
@@ -476,6 +476,27 @@ class DatabaseHelper {
     );
   }
 
+  Future<List<String>> getDistinctCategories() async {
+    final db = await database;
+    final List<Map<String, dynamic>> maps = await db.query(
+      TABLE_PRODUCTS,
+      distinct: true,
+      columns: ['category'],
+      orderBy: 'category ASC',
+    );
+
+    if (maps.isEmpty) {
+      return [];
+    }
+
+    List<String> categories = maps
+        .map((map) => map['category'] as String?)
+        .where((category) => category != null && category.trim().isNotEmpty)
+        .toList()
+        .cast<String>();
+    return categories;
+  }
+
   // Sales Table CRUD
   Future<void> insertSale(Map<String, dynamic> saleData) async {
     final db = await database;

--- a/gym_punto_venta/lib/dialogs/add_product_dialog.dart
+++ b/gym_punto_venta/lib/dialogs/add_product_dialog.dart
@@ -5,13 +5,15 @@ import 'package:gym_punto_venta/widgets/custom_form_field.dart';
 class AddProductDialog extends StatefulWidget {
   final bool darkMode;
   final Function(Product) onProductSaved;
-  final Product? initialProduct; // Para futura edición si se decide unificar
+  final Product? initialProduct;
+  final List<String> availableCategories; // Lista de categorías existentes
 
   const AddProductDialog({
     Key? key,
     required this.darkMode,
     required this.onProductSaved,
     this.initialProduct,
+    required this.availableCategories,
   }) : super(key: key);
 
   @override
@@ -21,41 +23,86 @@ class AddProductDialog extends StatefulWidget {
 class _AddProductDialogState extends State<AddProductDialog> {
   final _formKey = GlobalKey<FormState>();
   final _nameController = TextEditingController();
-  final _categoryController = TextEditingController();
   final _priceController = TextEditingController();
   final _stockController = TextEditingController();
+
+  // State for categories
+  String? _selectedCategory;
+  bool _showNewCategoryField = false;
+  final _newCategoryController = TextEditingController();
+  List<String> _allCategories = [];
+  static const String _addNewCategoryValue = 'ADD_NEW_CATEGORY_VALUE';
 
   @override
   void initState() {
     super.initState();
+    _allCategories = List.from(widget.availableCategories);
+
     if (widget.initialProduct != null) {
       _nameController.text = widget.initialProduct!.name;
-      _categoryController.text = widget.initialProduct!.category;
       _priceController.text = widget.initialProduct!.price.toString();
       _stockController.text = widget.initialProduct!.stock.toString();
+      // Set initial category for editing
+      if (_allCategories.contains(widget.initialProduct!.category)) {
+        _selectedCategory = widget.initialProduct!.category;
+      } else if (widget.initialProduct!.category.isNotEmpty) {
+        // If the product's category is not in the list (e.g. was added manually before this feature)
+        // Treat it as a new category entry for editing purposes.
+        _allCategories.add(widget.initialProduct!.category); // Temporarily add to list for display
+         _allCategories.sort(); // Keep sorted
+        _selectedCategory = widget.initialProduct!.category;
+        // Or, could opt to show it in the "new category" field:
+        // _showNewCategoryField = true;
+        // _newCategoryController.text = widget.initialProduct!.category;
+      }
+    } else {
+      // For new product, if categories exist, select the first one by default.
+      // if (_allCategories.isNotEmpty) {
+      // _selectedCategory = _allCategories.first;
+      // }
+      // Or leave null to force user selection
     }
   }
 
   @override
   void dispose() {
     _nameController.dispose();
-    _categoryController.dispose();
     _priceController.dispose();
     _stockController.dispose();
+    _newCategoryController.dispose();
     super.dispose();
   }
 
   void _saveProduct() {
     if (_formKey.currentState!.validate()) {
       String name = _nameController.text;
-      String category = _categoryController.text;
       double price = double.tryParse(_priceController.text) ?? 0.0;
       int stock = int.tryParse(_stockController.text) ?? 0;
+      String category = '';
+
+      if (_showNewCategoryField) {
+        category = _newCategoryController.text.trim();
+        if (category.isEmpty) {
+          // This should be caught by validator, but as a safeguard
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('El nombre de la nueva categoría no puede estar vacío.')),
+          );
+          return;
+        }
+      } else {
+        if (_selectedCategory == null || _selectedCategory!.isEmpty) {
+           ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Por favor seleccione o agregue una categoría.')),
+          );
+          return;
+        }
+        category = _selectedCategory!;
+      }
 
       final product = Product(
-        // id se asignará en la base de datos o por la función que guarda
+        id: widget.initialProduct?.id, // Preserve ID if editing
         name: name,
-        category: category,
+        category: category, // Use determined category
         price: price,
         stock: stock,
       );
@@ -91,18 +138,72 @@ class _AddProductDialogState extends State<AddProductDialog> {
                   return null;
                 },
               ),
-              CustomFormField(
-                controller: _categoryController,
-                labelText: 'Categoría',
-                hintText: 'Ej. Proteína, Pre-entreno',
-                darkMode: widget.darkMode,
+              // Category Dropdown
+              DropdownButtonFormField<String>(
+                decoration: InputDecoration(
+                  labelText: 'Categoría',
+                  labelStyle: TextStyle(color: widget.darkMode ? Colors.white70 : Colors.black54),
+                  enabledBorder: UnderlineInputBorder(
+                    borderSide: BorderSide(color: widget.darkMode ? Colors.white54 : Colors.black38),
+                  ),
+                  focusedBorder: UnderlineInputBorder(
+                    borderSide: BorderSide(color: widget.darkMode ? Colors.blueAccent : Colors.blue),
+                  ),
+                ),
+                dropdownColor: widget.darkMode ? Colors.grey[700] : Colors.white,
+                value: _selectedCategory,
+                hint: Text('Seleccione una categoría', style: TextStyle(color: widget.darkMode ? Colors.white54 : Colors.black38)),
+                isExpanded: true,
+                items: [
+                  ..._allCategories.map<DropdownMenuItem<String>>((String value) {
+                    return DropdownMenuItem<String>(
+                      value: value,
+                      child: Text(value, style: TextStyle(color: widget.darkMode ? Colors.white : Colors.black)),
+                    );
+                  }).toList(),
+                  DropdownMenuItem<String>(
+                    value: _addNewCategoryValue,
+                    child: Text('Agregar nueva categoría...', style: TextStyle(fontStyle: FontStyle.italic, color: widget.darkMode ? Colors.tealAccent : Colors.blue)),
+                  ),
+                ],
+                onChanged: (String? newValue) {
+                  setState(() {
+                    if (newValue == _addNewCategoryValue) {
+                      _showNewCategoryField = true;
+                      _selectedCategory = null; // Clear selection when adding new
+                    } else {
+                      _showNewCategoryField = false;
+                      _selectedCategory = newValue;
+                    }
+                  });
+                },
                 validator: (value) {
-                  if (value == null || value.isEmpty) {
-                    return 'Por favor ingrese la categoría';
+                  if (!_showNewCategoryField && value == null) {
+                    return 'Por favor seleccione una categoría';
                   }
                   return null;
                 },
               ),
+              if (_showNewCategoryField)
+                Padding(
+                  padding: const EdgeInsets.only(top: 8.0),
+                  child: CustomFormField(
+                    controller: _newCategoryController,
+                    labelText: 'Nombre de Nueva Categoría',
+                    darkMode: widget.darkMode,
+                    autofocus: true,
+                    validator: (value) {
+                      if (_showNewCategoryField && (value == null || value.isEmpty)) {
+                        return 'Ingrese el nombre de la nueva categoría';
+                      }
+                      if (_showNewCategoryField && _allCategories.map((c) => c.toLowerCase()).contains(value?.toLowerCase())) {
+                        return 'Esta categoría ya existe';
+                      }
+                      return null;
+                    },
+                  ),
+                ),
+
               CustomFormField(
                 controller: _priceController,
                 labelText: 'Precio (MXN)',

--- a/gym_punto_venta/lib/functions/funtions.dart
+++ b/gym_punto_venta/lib/functions/funtions.dart
@@ -133,6 +133,15 @@ class GymManagementFunctions {
     }
   }
 
+  Future<List<String>> getAvailableCategories() async {
+    try {
+      return await dbHelper.getDistinctCategories();
+    } catch (e) {
+      print('Error getting available categories: $e');
+      return []; // Return empty list on error
+    }
+  }
+
   Future<void> loadGymData() async {
     await migrateOldDataToSqliteIfNeeded();
 

--- a/gym_punto_venta/lib/widgets/balance_dashboard_widget.dart
+++ b/gym_punto_venta/lib/widgets/balance_dashboard_widget.dart
@@ -275,13 +275,13 @@ class _BalanceDashboardWidgetState extends State<BalanceDashboardWidget> {
                           });
                         }
                       },
-                      selectedColor: Theme.of(context).primaryColor,
+                      selectedColor: Colors.grey[600],
                       labelStyle: TextStyle(
                         color: _selectedPeriod == period
-                            ? (widget.darkMode ? Colors.black : Colors.white)
+                            ? (widget.darkMode ? Colors.white : Colors.white)
                             : textColor,
                       ),
-                      backgroundColor: widget.darkMode ? Colors.grey[700] : Colors.grey[300],
+                      backgroundColor: widget.darkMode ? Colors.grey : Colors.grey[300],
                     ),
                   );
                 }).toList(),
@@ -538,7 +538,7 @@ class _BalanceDashboardWidgetState extends State<BalanceDashboardWidget> {
           LineChartBarData(
             spots: _salesData,
             isCurved: true,
-            color: Theme.of(context).primaryColor,
+            color: Colors.blue,
             barWidth: 2,
             isStrokeCapRound: true,
             dotData: const FlDotData(show: false),
@@ -546,8 +546,8 @@ class _BalanceDashboardWidgetState extends State<BalanceDashboardWidget> {
               show: true,
               gradient: LinearGradient(
                 colors: [
-                  Theme.of(context).primaryColor.withOpacity(0.3),
-                  Theme.of(context).primaryColor.withOpacity(0.0)
+                  Colors.blue.withOpacity(0.3),
+                  Colors.blue.withOpacity(0.0)
                 ],
                 begin: Alignment.topCenter,
                 end: Alignment.bottomCenter,

--- a/gym_punto_venta/lib/widgets/balance_dashboard_widget.dart
+++ b/gym_punto_venta/lib/widgets/balance_dashboard_widget.dart
@@ -275,13 +275,13 @@ class _BalanceDashboardWidgetState extends State<BalanceDashboardWidget> {
                           });
                         }
                       },
-                      selectedColor: Colors.grey[600],
+                      selectedColor: Theme.of(context).primaryColor,
                       labelStyle: TextStyle(
                         color: _selectedPeriod == period
-                            ? (widget.darkMode ? Colors.white : Colors.white)
+                            ? (widget.darkMode ? Colors.black : Colors.white)
                             : textColor,
                       ),
-                      backgroundColor: widget.darkMode ? Colors.grey : Colors.grey[300],
+                      backgroundColor: widget.darkMode ? Colors.grey[700] : Colors.grey[300],
                     ),
                   );
                 }).toList(),
@@ -538,7 +538,7 @@ class _BalanceDashboardWidgetState extends State<BalanceDashboardWidget> {
           LineChartBarData(
             spots: _salesData,
             isCurved: true,
-            color: Colors.blue,
+            color: Theme.of(context).primaryColor,
             barWidth: 2,
             isStrokeCapRound: true,
             dotData: const FlDotData(show: false),
@@ -546,8 +546,8 @@ class _BalanceDashboardWidgetState extends State<BalanceDashboardWidget> {
               show: true,
               gradient: LinearGradient(
                 colors: [
-                  Colors.blue.withOpacity(0.3),
-                  Colors.blue.withOpacity(0.0)
+                  Theme.of(context).primaryColor.withOpacity(0.3),
+                  Theme.of(context).primaryColor.withOpacity(0.0)
                 ],
                 begin: Alignment.topCenter,
                 end: Alignment.bottomCenter,

--- a/gym_punto_venta/lib/widgets/custom_form_field.dart
+++ b/gym_punto_venta/lib/widgets/custom_form_field.dart
@@ -9,6 +9,7 @@ class CustomFormField extends StatelessWidget {
   final TextInputType keyboardType;
   final List<TextInputFormatter>? inputFormatters;
   final String? hintText;
+  final bool autofocus;
 
   const CustomFormField({
     Key? key,
@@ -19,6 +20,7 @@ class CustomFormField extends StatelessWidget {
     this.keyboardType = TextInputType.text,
     this.inputFormatters,
     this.hintText,
+    this.autofocus = false,
   }) : super(key: key);
 
   @override
@@ -52,6 +54,7 @@ class CustomFormField extends StatelessWidget {
         validator: validator,
         keyboardType: keyboardType,
         inputFormatters: inputFormatters,
+        autofocus: autofocus,
       ),
     );
   }


### PR DESCRIPTION
Implementar categorías seleccionables y agregables para productos
- Modificado `AddProductDialog` para permitir seleccionar una categoría de producto desde una lista desplegable o agregar una nueva categoría.
- `DatabaseHelper` ahora incluye `getDistinctCategories()` para obtener la lista de categorías únicas.
- `GymManagementFunctions` expone `getAvailableCategories()`.
- `PrincipalScreen` carga las categorías disponibles y las pasa al diálogo. La lista de categorías se actualiza después de agregar un producto para reflejar nuevas adiciones.
- Añadidas validaciones para el campo de nueva categoría (no vacío, no duplicado).